### PR TITLE
fix(container): drop the Windows root component when classifying streams

### DIFF
--- a/crates/rpt/src/container/stream_id.rs
+++ b/crates/rpt/src/container/stream_id.rs
@@ -53,7 +53,7 @@ impl StreamId {
         let comps: Vec<String> = path
             .components()
             .filter_map(|c| c.as_os_str().to_str().map(str::to_owned))
-            .filter(|s| !s.is_empty() && s != "/")
+            .filter(|s| !s.is_empty() && s != "/" && s != "\\")
             .collect();
 
         let Some(top) = comps.first() else {
@@ -159,5 +159,17 @@ mod tests {
             id("/Embedding 1/CONTENTS"),
             StreamId::Embedding("Embedding 1/CONTENTS".into())
         );
+    }
+
+    /// The OLE root component is platform-dependent: `Path::components()`
+    /// renders it as `/` on Unix but `\` on Windows. Both must be dropped, or
+    /// every top-level stream gains a phantom leading component, takes the
+    /// nested-entry branch, and is misclassified as `Other` — which on Windows
+    /// left `Contents` unrecognised and nothing decodable.
+    #[test]
+    fn root_component_is_dropped_on_every_platform() {
+        for path in ["/Contents", r"\Contents", "Contents"] {
+            assert_eq!(id(path), StreamId::Contents, "path {path:?}");
+        }
     }
 }


### PR DESCRIPTION
## Problem

On Windows, `rpt` decodes nothing: `rpt inspect` reports `0 records` for every
`.rpt` file (including this repo's own fixtures), and renders come out blank.

Stream names surface with a phantom leading root, e.g.:

```
streams:
  Other("\/Contents")           8385 bytes
  Other("\/QESession")          3874 bytes
```

## Cause

`StreamId::classify` drops the OLE path's root component with `s != "/"`:

```rust
.filter(|s| !s.is_empty() && s != "/")
```

`Path::components()` renders the root as `/` on Unix but `\` on Windows, so on
Windows the root survives the filter. Every top-level stream then has two
components, takes the "nested entries keep their full path" branch, and is
returned as `Other("\/Contents")` rather than `StreamId::Contents`.

Since only `Contents` is `is_tslv()`, the codec layer never decodes anything.

Minimal demonstration (Windows, rustc 1.95):

```rust
let comps: Vec<String> = Path::new("/Contents").components()
    .filter_map(|c| c.as_os_str().to_str().map(str::to_owned))
    .filter(|s| !s.is_empty() && s != "/")
    .collect();
// Unix:    ["Contents"]
// Windows: ["\\", "Contents"]   <-- root survives
```

## Fix

Drop the Windows root spelling as well — one line:

```rust
.filter(|s| !s.is_empty() && s != "/" && s != "\\")
```

## Existing tests already catch this

The unit tests in `stream_id.rs` assert the correct behaviour and fail on
Windows before the change:

- `classifies_top_level_streams`
- `classifies_summary_information_with_control_prefix`
- `classifies_indexed_streams`
- `nested_embedding_keeps_full_path`

7 of 8 integration tests in `crates/rpt/tests/chart_legend.rs` fail as well.
They presumably just haven't been run on Windows yet.

## Verification (Windows 11, rustc 1.95, release build)

Before:

```
report: version=0 · 0 records · 0 distinct types
```

After:

```
report: version=1 · 1475 records · 93 distinct types
  top record types: NumericFieldFormat×72  NumericFieldFormatWrapper×72 …
  fields (38): Date:DateTime, BudgetValue:Number, ActualValue:Number, …
```

(`tests/fixtures/reports/ajryan/B1Budget_M.rpt`)

`cargo test --release`: **600 tests pass.** One failure remains —
`rpt-pages::tests::golden_page_ir_json` — which compares the golden JSON
fixture (checked out with CRLF on Windows) against LF output. That's a
separate, test-only issue; happy to open it as its own report if useful.

## Also included

A regression test covering both root spellings, so the platform difference
can't silently come back:

```rust
#[test]
fn root_component_is_dropped_on_every_platform() {
    for path in ["/Contents", r"\Contents", "Contents"] {
        assert_eq!(id(path), StreamId::Contents, "path {path:?}");
    }
}
```

---

Context: I evaluated rpt-rs as a possible extraction backend for a Crystal
Reports → Pentaho Report Designer migration tool, specifically because it
reads cross-tab dimensions from the binary — something the SAP .NET SDK
seals behind reserved COM slots. With this fix applied, those records decode
here (`CrossTabDimension → CrossTabDimensionGroup → CrossTabDimensionField`,
with real field names). Thanks for building this.
